### PR TITLE
installer/linux: run service under non-root service account

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/git-ecosystem/sample-trace2-otel-collector
 go 1.21
 
 require (
-	github.com/git-ecosystem/trace2receiver v0.5.0
+	github.com/git-ecosystem/trace2receiver v0.5.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter v0.89.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.89.0

--- a/go.sum
+++ b/go.sum
@@ -657,6 +657,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/git-ecosystem/trace2receiver v0.5.0 h1:VujzX41g9OLSFPTwFAUUIVEYrpwcqDMviKTA6ddRiXs=
 github.com/git-ecosystem/trace2receiver v0.5.0/go.mod h1:q1yNvIlFj3Xa7ybKuOpsr0epC5TFY53ZrPkvnz/j4iI=
+github.com/git-ecosystem/trace2receiver v0.5.1 h1:btgJYtcArzrzNZgp1gzm+589xjqeLQyEOIlwZtCOVVs=
+github.com/git-ecosystem/trace2receiver v0.5.1/go.mod h1:q1yNvIlFj3Xa7ybKuOpsr0epC5TFY53ZrPkvnz/j4iI=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=

--- a/installers/linux/Makefile
+++ b/installers/linux/Makefile
@@ -31,6 +31,13 @@ DST    := ./_out_/_layout_/usr/local/sample-trace2-otel-collector
 DEBIAN := ./_out_/_layout_/DEBIAN
 ETC    := ./_out_/_layout_/etc/systemd/system
 
+################################################################
+
+.PHONY: default
+default: layout package
+
+################################################################
+
 .PHONY: layout
 layout:
 	@echo "======== Creating Layout ========"

--- a/installers/linux/deb-scripts/postinst
+++ b/installers/linux/deb-scripts/postinst
@@ -1,6 +1,18 @@
 #!/bin/sh
 
-set -e
+# Pseudo user identity that the collector service will use. This
+# should be the name of a "system" UID with very few privileges and no
+# shell or login. It will only own a few files and directories in the
+# install directory so that it can create the Unix domain socket and
+# write to the stdout/stderr logs.
+#
+# We will create it during the install -- if it doesn't already exist
+# (from a previous installation).
+#
+# The username chosen here must match the `User=` and `Group=` keys
+# in the `.service` file.
+
+USERNAME=trace2
 
 INSTALL_LOCATION=/usr/local/sample-trace2-otel-collector
 
@@ -18,6 +30,30 @@ echo ""
 date
 
 set -x
+
+grep "^$USERNAME:" /etc/passwd
+if [ $? -eq 0 ]
+then
+    echo "Using existing pseudo user $USERNAME"
+else
+    echo "Trying to create system pseudo user $USERNAME"
+
+    /usr/sbin/adduser --system --group --no-create-home $USERNAME
+    RESULT=$?
+    if [ $RESULT -ne 0 ]
+    then
+	echo "Could not create pseudo user $USERNAME"
+	exit $RESULT
+    fi
+fi
+
+# Let the service process own the install directory so that it can
+# create the Unix domain socket in it.  Also recursively give it
+# the logs directory so that it can create/extend the
+# stdout/stderr logs.
+
+chown    $USERNAME:$USERNAME $INSTALL_LOCATION
+chown -R $USERNAME:$USERNAME $INSTALL_LOCATION/logs
 
 echo Attempting to start sample-trace2-otel-collector
 $INSTALL_LOCATION/scripts/service_start

--- a/installers/linux/deb-scripts/prerm
+++ b/installers/linux/deb-scripts/prerm
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 INSTALL_LOCATION=/usr/local/sample-trace2-otel-collector
 
 mkdir -p "$INSTALL_LOCATION/logs"

--- a/installers/linux/sample-trace2-otel-collector.service
+++ b/installers/linux/sample-trace2-otel-collector.service
@@ -7,8 +7,8 @@ ExecStart=/usr/local/sample-trace2-otel-collector/bin/sample-trace2-otel-collect
 KillMode=mixed
 Restart=on-failure
 Type=simple
-User=root
-Group=root
+User=trace2
+Group=trace2
 
 [Install]
 WantedBy=multi-user.target

--- a/installers/linux/scripts/service_start
+++ b/installers/linux/scripts/service_start
@@ -2,7 +2,6 @@
 
 INSTALL_LOCATION=/usr/local/sample-trace2-otel-collector
 
-set -e
 set -x
 
 if command -v systemctl >/dev/null 2>&1

--- a/installers/linux/scripts/service_stop
+++ b/installers/linux/scripts/service_stop
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-set -e
 set -x
 
 INSTALL_LOCATION=/usr/local/sample-trace2-otel-collector


### PR DESCRIPTION
Update the linux installer scripts to create a low privileged, non-interactive, service account on the system.

Update the `sample-trace2-otel-collector.service` to tell `systemctl` to run the collector service under our new service account.

Chown a few of the directories and files in the installation directory so that the service can function with these reduced privileges. This is just enough to let the service create the Unix domain socket and write the various install/stdout/stderr logs.  The remainder of the installation is still owned by the installing user or root.

The user name "trace2" is used by default.

Additionally, updated the various scripts to remove the `set -e` option. This was causing difficulties for for `dpkg` when we actually wanted to use the exit code for branching within the scripts.